### PR TITLE
Fix Python 3 related errors, replace IOError with EOFError

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ l = []
 wrapper = ByteWrapper(l.append)
 f = bit_wrap(wrapper, "w")
 f.write_bits(0b110000101, 10)
-print l # ["a"]
+print(l)    # [b"a"]
 f.close()
-print l # ["a", "@"]
+print(l)    # [b"a", b"@"]
 ```

--- a/bitio/__init__.py
+++ b/bitio/__init__.py
@@ -3,7 +3,7 @@
 # bitio/bit_file.py
 #
 """\
-Input/output utirites of a bit-basis file.
+Input/output utilities of a bit-basis file.
 
 ------------------------------------------
 how to use:
@@ -23,9 +23,9 @@ l = []
 wrapper = ByteWrapper(l.append)
 f = bit_wrap(wrapper, "w")
 f.write_bits(0b110000101, 10)
-print l # ["a"]
+print(l)    # [b"a"]
 f.close()
-print l # ["a", "@"]
+print(l)    # [b"a", b"@"]
 """
 
 

--- a/bitio/bit_file.py
+++ b/bitio/bit_file.py
@@ -36,8 +36,8 @@ class BitFileReader(_BaseBitFile):
     
     def _read_byte(self):
         c = self.byte_file.read(1)
-        if c == '':
-            raise IOError("Bit file is empty!")
+        if not c:
+            raise EOFError("Bit file is empty!")
         return ord(c)
         
     def read(self):
@@ -84,7 +84,7 @@ class BitFileWriter(_BaseBitFile):
         return writer
 
     def _flush_byte(self):
-        self.byte_file.write(chr(self.rack))
+        self.byte_file.write(self.rack.to_bytes())
         self.rack = 0
         self.mask = 0x80
         

--- a/bitio/byte_wrapper.py
+++ b/bitio/byte_wrapper.py
@@ -12,7 +12,7 @@ class ByteWrapper(object):
         try:
             s = self.callable_object()
         except:
-            s = ""
+            s = bytes(0)
         return s
 
     def write(self, byte):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name = "bitio",
     packages = ["bitio"],
     version = "0.2",
-    description = "Input/output utirites of a bit-basis file",
+    description = "Input/output utilities of a bit-basis file",
     author = "Daiju Nakayama",
     author_email = "42.daiju@gmail.com",
     url = "https://github.com/hinohi/bitio",

--- a/test.py
+++ b/test.py
@@ -50,27 +50,27 @@ class TestReader(unittest.TestCase):
         with bitio.BitFileReader(self.test_file_name) as f:
             for i in ([0, 1, 1, 0]*2 + [1] + [0]*7):
                 self.assertEqual(f.read(), i)
-            self.assertRaises(IOError, f.read)
+            self.assertRaises(EOFError, f.read)
 
     def test_read(self):
         f = bitio.BitFileReader(self.test_file_name)
         for i in ([0, 1, 1, 0]*2 + [1] + [0]*7):
             self.assertEqual(f.read(), i)
-        self.assertRaises(IOError, f.read)
+        self.assertRaises(EOFError, f.read)
         f.close()
 
     def test_read_bits(self):
         f = bitio.BitFileReader(self.test_file_name)
         self.assertEqual(f.read_bits(9), 0b011001101)
         self.assertEqual(f.read_bits(7), 0)
-        self.assertRaises(IOError, f.read_bits, 1)
+        self.assertRaises(EOFError, f.read_bits, 1)
         f.close()
 
     def test_empty(self):
         emp_file = "emp"
         open(emp_file, "wb").close()
         f = bitio.BitFileReader(emp_file)
-        self.assertRaises(IOError, f.read)
+        self.assertRaises(EOFError, f.read)
         f.close()
         os.remove(emp_file)
 
@@ -81,18 +81,17 @@ class TestWrapper(unittest.TestCase):
         wrapper = bitio.ByteWrapper(l.append)
         f = bitio.bit_wrap(wrapper, "w")
         f.write_bits(0b0110000101, 10)
-        self.assertEqual(l, ["a"])
+        self.assertEqual(l, [b"a"])
         f.close()
-        self.assertEqual(l, ["a", "@"])
+        self.assertEqual(l, [b"a", b"@"])
 
     def test_read(self):
-        l = ["a", "@"][::-1]
-        ll = l[::-1]
+        l = [b"a", b"@"][::-1]
         wrapper = bitio.ByteWrapper(l.pop)
         f = bitio.bit_wrap(wrapper, "r")
         for i in [0,1,1,0,0,0,0,1,0,1,0,0,0,0,0,0]:
             self.assertEqual(f.read(), i)
-        self.assertRaises(IOError, f.read)
+        self.assertRaises(EOFError, f.read)
         f.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi, I needed to use this library in my project, but I found some Python 2 vs 3 related errors, so I fixed them. I also replaced IOError with EOFError if there is an attempt to read more bytes than available in a file. While I was at it, I also fixed some small typos.

Btw, this might break Python 2 compatibility, I'm not really sure about that.